### PR TITLE
fix(UserRegistrationDTO): Put min and max size assertions on first an…

### DIFF
--- a/src/main/java/com/pecunia/api/dto/UserRegistrationDTO.java
+++ b/src/main/java/com/pecunia/api/dto/UserRegistrationDTO.java
@@ -5,25 +5,37 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @PasswordMatches
 @Schema(name = "User Registration DTO", description = "Use password matcher and a regex")
 public class UserRegistrationDTO {
 
-  @NotBlank(message = "Le prénom est obligatoire.")
-  @Pattern(regexp = "^[A-Za-zÀ-ÿ\\-]+$", message = "Le prénom ne doit contenir que des lettres ou des tirets sans espaces.")
+  @Pattern(
+      regexp = "^(?=.*[A-Za-zÀ-ÿ])[A-Za-zÀ-ÿ\\-]+$",
+      message =
+          "Le prénom doit contenir uniquement des lettres (avec accents) et des tirets, sans"
+              + " chiffres ni espaces.")
+  @Size(min = 2, max = 50, message = "Le prénom doit contenir entre 2 et 50 caractères")
   private String firstname;
 
-  @NotBlank(message = "Le nom est obligatoire.")
-  @Pattern(regexp = "^[A-Za-zÀ-ÿ\\-]+$", message = "Le nom ne doit contenir que des lettres ou des tirets sans espaces.")
+  @Pattern(
+      regexp = "^(?=.*[A-Za-zÀ-ÿ])[A-Za-zÀ-ÿ\\-]+$",
+      message =
+          "Le prénom doit contenir uniquement des lettres (avec accents) et des tirets, sans"
+              + " chiffres ni espaces.")
+  @Size(min = 2, max = 50, message = "Le prénom doit contenir entre 2 et 50 caractères")
   private String lastname;
 
   @Email(message = "Email invalide.")
   private String email;
 
   @NotBlank(message = "Le mot de passe est obligatoire.")
-  @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+!?=])(?=\\S+$).{12,}$",
-  message = "Le mot de passe doit contenir au moins 12 caractères, une majuscule, un chiffre et un caractère spécial.")
+  @Pattern(
+      regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+!?=])(?=\\S+$).{12,}$",
+      message =
+          "Le mot de passe doit contenir au moins 12 caractères, une majuscule, un chiffre et un"
+              + " caractère spécial.")
   private String password;
 
   @NotBlank(message = "Veuillez confirmer votre mot de passe.")
@@ -49,15 +61,15 @@ public class UserRegistrationDTO {
     return email;
   }
 
-    public void setEmail(String email) {
+  public void setEmail(String email) {
     this.email = email;
   }
 
-    public String getPassword() {
+  public String getPassword() {
     return password;
   }
 
-    public void setPassword(String password) {
+  public void setPassword(String password) {
     this.password = password;
   }
 


### PR DESCRIPTION
## [187 - iSSUE - UserRegistrationDTO](https://tree.taiga.io/project/lenny-zanotelli-pecunia/issue/187)

- Put min and max size assertions on first and lastname.
- Improve the regex on those fields with letters and no numbers
