### PR TITLE
58 - create delete endpoint for providers

### DIFF
--- a/src/main/java/com/pecunia/api/controller/ProviderController.java
+++ b/src/main/java/com/pecunia/api/controller/ProviderController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -105,5 +106,16 @@ public class ProviderController {
     return updatedProvider == null
         ? ResponseEntity.notFound().build()
         : ResponseEntity.ok(updatedProvider);
+  }
+
+  @DeleteMapping("/{providerId}")
+  @Operation(
+      summary = "Delete a specific Provider by Id",
+      description = "Role admin require or login with correct user id.")
+  @CanAccessProvider
+  public ResponseEntity<Void> deleteProvider(@PathVariable Long providerId) {
+    return providerService.delete(providerId)
+        ? ResponseEntity.noContent().build()
+        : ResponseEntity.notFound().build();
   }
 }

--- a/src/main/java/com/pecunia/api/dto/transaction/TransactionCreateDto.java
+++ b/src/main/java/com/pecunia/api/dto/transaction/TransactionCreateDto.java
@@ -23,6 +23,15 @@ public class TransactionCreateDto {
   private Long walletId;
 
   private Set<Long> tagsIds;
+  private Long providerId;
+
+  public Long getProviderId() {
+    return providerId;
+  }
+
+  public void setProviderId(Long providerId) {
+    this.providerId = providerId;
+  }
 
   public Money getAmount() {
     return amount;

--- a/src/main/java/com/pecunia/api/dto/transaction/TransactionDto.java
+++ b/src/main/java/com/pecunia/api/dto/transaction/TransactionDto.java
@@ -2,6 +2,7 @@ package com.pecunia.api.dto.transaction;
 
 import com.pecunia.api.dto.tag.TagDto;
 import com.pecunia.api.model.Money;
+import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.TransactionType;
 import java.time.LocalDateTime;
 import java.util.Set;
@@ -13,6 +14,7 @@ public class TransactionDto {
   private String note;
   private Money amount;
   private Set<TagDto> tags;
+  private Provider provider;
 
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
@@ -71,5 +73,13 @@ public class TransactionDto {
 
   public void setTags(Set<TagDto> tags) {
     this.tags = tags;
+  }
+
+  public Provider getProvider() {
+    return provider;
+  }
+
+  public void setProvider(Provider provider) {
+    this.provider = provider;
   }
 }

--- a/src/main/java/com/pecunia/api/dto/transaction/TransactionUpdateDto.java
+++ b/src/main/java/com/pecunia/api/dto/transaction/TransactionUpdateDto.java
@@ -20,6 +20,15 @@ public class TransactionUpdateDto {
   private LocalDateTime createdAt;
 
   private Set<Long> tagsIds;
+  private Long providerId;
+
+  public Long getProviderId() {
+    return providerId;
+  }
+
+  public void setProviderId(Long providerId) {
+    this.providerId = providerId;
+  }
 
   public LocalDateTime getCreatedAt() {
     return createdAt;

--- a/src/main/java/com/pecunia/api/mapper/TransactionMapper.java
+++ b/src/main/java/com/pecunia/api/mapper/TransactionMapper.java
@@ -4,6 +4,7 @@ import com.pecunia.api.dto.tag.TagDto;
 import com.pecunia.api.dto.transaction.TransactionCreateDto;
 import com.pecunia.api.dto.transaction.TransactionDto;
 import com.pecunia.api.dto.transaction.TransactionUpdateDto;
+import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
 import com.pecunia.api.model.Wallet;
@@ -37,18 +38,20 @@ public class TransactionMapper {
           transaction.getTags().stream().map(tagMapper::convertToDto).collect(Collectors.toSet());
       dto.setTags(tagDtos);
     }
+    dto.setProvider(transaction.getProvider());
 
     return dto;
   }
 
   public Transaction convertCreateDtoToEntity(
-      TransactionCreateDto dto, Wallet wallet, Set<Tag> tags) {
+      TransactionCreateDto dto, Wallet wallet, Set<Tag> tags, Provider provider) {
     Transaction transaction = new Transaction();
     transaction.setAmount(dto.getAmount());
     transaction.setNote(dto.getNote());
     transaction.setType(dto.getType());
     transaction.setTags(tags);
     transaction.setWallet(wallet);
+    transaction.setProvider(provider);
 
     return transaction;
   }
@@ -64,6 +67,7 @@ public class TransactionMapper {
           transaction.getTags().stream().map(Tag::getId).collect(Collectors.toSet());
       dto.setTagsIds(tagsIds);
     }
+    dto.setProviderId(transaction.getProvider().getId());
 
     return dto;
   }
@@ -79,6 +83,7 @@ public class TransactionMapper {
           transaction.getTags().stream().map(Tag::getId).collect(Collectors.toSet());
       dto.setTagsIds(tagsIds);
     }
+    dto.setProviderId(transaction.getProvider().getId());
 
     return dto;
   }

--- a/src/main/java/com/pecunia/api/mapper/TransactionMapper.java
+++ b/src/main/java/com/pecunia/api/mapper/TransactionMapper.java
@@ -51,7 +51,10 @@ public class TransactionMapper {
     transaction.setType(dto.getType());
     transaction.setTags(tags);
     transaction.setWallet(wallet);
-    transaction.setProvider(provider);
+    if (transaction.getProvider() != null) {
+      transaction.setProvider(provider);
+    }
+    transaction.setProvider(null);
 
     return transaction;
   }

--- a/src/main/java/com/pecunia/api/service/ProviderService.java
+++ b/src/main/java/com/pecunia/api/service/ProviderService.java
@@ -6,6 +6,7 @@ import com.pecunia.api.dto.provider.ProviderUpdateDto;
 import com.pecunia.api.exception.ResourceNotFoundException;
 import com.pecunia.api.mapper.ProviderMapper;
 import com.pecunia.api.model.Provider;
+import com.pecunia.api.model.Transaction;
 import com.pecunia.api.model.User;
 import com.pecunia.api.repository.ProviderRepository;
 import com.pecunia.api.repository.UserRepository;
@@ -64,6 +65,21 @@ public class ProviderService {
     }
     Provider updatedProvider = providerRepository.save(provider);
     return providerMapper.convertToUpdateDto(updatedProvider);
+  }
+
+  public boolean delete(Long providerId) {
+    Provider provider = getProviderByIdOrThrow(providerId);
+    if (provider == null) {
+      return false;
+    }
+    if (provider.getTransactions() != null) {
+      for (Transaction transaction : provider.getTransactions()) {
+        transaction.setProvider(null);
+      }
+      provider.getTransactions().clear();
+    }
+    providerRepository.delete(provider);
+    return true;
   }
 
   private Provider getProviderByIdOrThrow(Long providerId) {

--- a/src/main/java/com/pecunia/api/service/TransactionService.java
+++ b/src/main/java/com/pecunia/api/service/TransactionService.java
@@ -102,10 +102,13 @@ public class TransactionService {
         throw new IllegalArgumentException("Certains tags n'existents pas.");
       }
     }
-    Provider provider =
-        providerRepository
-            .findById(transactionCreateDto.getProviderId())
-            .orElseThrow(() -> new IllegalArgumentException("Provider not found"));
+    Provider provider = new Provider();
+    if (transactionCreateDto.getProviderId() != null) {
+      provider =
+          providerRepository
+              .findById(transactionCreateDto.getProviderId())
+              .orElseThrow(() -> new IllegalArgumentException("Provider not found"));
+    }
     Transaction transaction =
         transactionMapper.convertCreateDtoToEntity(transactionCreateDto, wallet, tags, provider);
     Transaction savedTransaction = transactionRepository.save(transaction);
@@ -177,8 +180,9 @@ public class TransactionService {
       }
       transaction.setTags(newTags);
     }
+    Provider newProvider = new Provider();
     if (transactionUpdateDto.getProviderId() != null) {
-      Provider newProvider =
+      newProvider =
           providerRepository
               .findById(transactionUpdateDto.getProviderId())
               .orElseThrow(() -> new IllegalArgumentException("Provider n'existe pas."));

--- a/src/test/java/com/pecunia/api/MoneyTest.java
+++ b/src/test/java/com/pecunia/api/MoneyTest.java
@@ -1,12 +1,50 @@
 package com.pecunia.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.pecunia.api.exception.CannotAddTwoCurrenciesException;
 import com.pecunia.api.model.Money;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Currency;
 import org.junit.jupiter.api.Test;
 
 /** MoneyTest. */
 public class MoneyTest {
+
+  @Test
+  public void testConstructorWithDoubleAndCurrency() {
+    Money money = new Money(10.50, Currency.getInstance("EUR"));
+    assertEquals(new BigDecimal("10.50"), money.amount());
+    assertEquals(Currency.getInstance("EUR"), money.currency());
+  }
+
+  @Test
+  public void testConstructorWithDoubleAndCodeCurrency() {
+    Money money = new Money(25.75, "USD");
+    assertEquals(new BigDecimal("25.75"), money.amount());
+    assertEquals(Currency.getInstance("USD"), money.currency());
+  }
+
+  @Test
+  public void testConstructorWithLongAndCurrency() {
+    Money money = new Money(1050L, Currency.getInstance("EUR"));
+    assertEquals(new BigDecimal("1050.00"), money.amount());
+    assertEquals(Currency.getInstance("EUR"), money.currency());
+  }
+
+  @Test
+  public void testConstructorWithBigDecimalAndRoundingMode() {
+    BigDecimal amount = new BigDecimal("10.555");
+    Money money = new Money(amount, Currency.getInstance("EUR"), RoundingMode.HALF_UP);
+    assertEquals(new BigDecimal("10.56"), money.amount());
+    assertEquals(Currency.getInstance("EUR"), money.currency());
+  }
 
   @Test
   public void testAllocate() {
@@ -14,5 +52,248 @@ public class MoneyTest {
     Money[] result = Money.euros(0.05).allocate(allocation);
     assertEquals(Money.euros(0.02), result[0]);
     assertEquals(Money.euros(0.03), result[1]);
+  }
+
+  @Test
+  public void testEuros() {
+    Money euros = Money.euros(15.99);
+    assertEquals(new BigDecimal("15.99"), euros.amount());
+    assertEquals(Currency.getInstance("EUR"), euros.currency());
+    assertEquals("EUR", euros.getCurrencyCode());
+  }
+
+  @Test
+  public void testDollars() {
+    Money dollars = Money.dollars(42.33);
+    assertEquals(new BigDecimal("42.33"), dollars.amount());
+    assertEquals(Currency.getInstance("USD"), dollars.currency());
+    assertEquals("USD", dollars.getCurrencyCode());
+  }
+
+  @Test
+  public void testGetCurrencySymbol() {
+    Money euros = Money.euros(100.0);
+    Money dollars = Money.dollars(100.0);
+
+    assertNotNull(euros.getCurrencySymbol());
+    assertNotNull(dollars.getCurrencySymbol());
+  }
+
+  @Test
+  public void testEqualsWithSameMoney() {
+    Money money1 = Money.euros(25.50);
+    Money money2 = Money.euros(25.50);
+
+    assertTrue(money1.equals(money2));
+    assertEquals(money1, money2);
+    assertEquals(money1.hashCode(), money2.hashCode());
+  }
+
+  @Test
+  public void testEqualsWithDifferentAmounts() {
+    Money money1 = Money.euros(25.50);
+    Money money2 = Money.euros(30.00);
+
+    assertFalse(money1.equals(money2));
+    assertNotEquals(money1, money2);
+  }
+
+  @Test
+  public void testEqualsWithDifferentCurrencies() {
+    Money euros = Money.euros(25.50);
+    Money dollars = Money.dollars(25.50);
+
+    assertFalse(euros.equals(dollars));
+    assertNotEquals(euros, dollars);
+  }
+
+  @Test
+  public void testAddWithSameCurrency() {
+    Money money1 = Money.euros(10.50);
+    Money money2 = Money.euros(5.25);
+    Money result = money1.add(money2);
+
+    assertEquals(Money.euros(15.75), result);
+    assertEquals("EUR", result.getCurrencyCode());
+  }
+
+  @Test
+  public void testAddWithDifferentCurrencies() {
+    Money euros = Money.euros(10.50);
+    Money dollars = Money.dollars(5.25);
+
+    assertThrows(
+        CannotAddTwoCurrenciesException.class,
+        () -> {
+          euros.add(dollars);
+        });
+  }
+
+  @Test
+  public void testSubstractWithSameCurrency() {
+    Money money1 = Money.euros(15.75);
+    Money money2 = Money.euros(5.25);
+    Money result = money1.substract(money2);
+
+    assertEquals(Money.euros(10.50), result);
+    assertEquals("EUR", result.getCurrencyCode());
+  }
+
+  @Test
+  public void testSubstractWithDifferentCurrencies() {
+    Money euros = Money.euros(15.75);
+    Money dollars = Money.dollars(5.25);
+
+    assertThrows(
+        CannotAddTwoCurrenciesException.class,
+        () -> {
+          euros.substract(dollars);
+        });
+  }
+
+  @Test
+  public void testMultiplyByDouble() {
+    Money money = Money.euros(10.00);
+    Money result = money.multiply(2.5);
+
+    assertEquals(Money.euros(25.00), result);
+    assertEquals("EUR", result.getCurrencyCode());
+  }
+
+  @Test
+  public void testMultiplyByBigDecimal() {
+    Money money = Money.euros(10.00);
+    BigDecimal multiplier = new BigDecimal("1.5");
+    Money result = money.multiply(multiplier);
+
+    assertEquals(Money.euros(15.00), result);
+    assertEquals("EUR", result.getCurrencyCode());
+  }
+
+  @Test
+  public void testMultiplyByBigDecimalWithRounding() {
+    Money money = Money.euros(10.00);
+    BigDecimal multiplier = new BigDecimal("0.333");
+    Money result = money.multiply(multiplier, RoundingMode.HALF_EVEN);
+
+    assertEquals(Money.euros(3.33), result);
+    assertEquals("EUR", result.getCurrencyCode());
+  }
+
+  @Test
+  public void testCompareToEqual() {
+    Money money1 = Money.euros(25.50);
+    Money money2 = Money.euros(25.50);
+
+    assertEquals(0, money1.compareTo(money2));
+  }
+
+  @Test
+  public void testCompareToGreater() {
+    Money money1 = Money.euros(30.00);
+    Money money2 = Money.euros(25.50);
+
+    assertTrue(money1.compareTo(money2) > 0);
+  }
+
+  @Test
+  public void testCompareToSmaller() {
+    Money money1 = Money.euros(20.00);
+    Money money2 = Money.euros(25.50);
+
+    assertTrue(money1.compareTo(money2) < 0);
+  }
+
+  @Test
+  public void testCompareToWithDifferentCurrencies() {
+    Money euros = Money.euros(25.50);
+    Money dollars = Money.dollars(25.50);
+
+    assertThrows(
+        CannotAddTwoCurrenciesException.class,
+        () -> {
+          euros.compareTo(dollars);
+        });
+  }
+
+  @Test
+  public void testGreaterThanTrue() {
+    Money money1 = Money.euros(30.00);
+    Money money2 = Money.euros(25.50);
+
+    assertTrue(money1.greaterThan(money2));
+  }
+
+  @Test
+  public void testGreaterThanFalse() {
+    Money money1 = Money.euros(20.00);
+    Money money2 = Money.euros(25.50);
+
+    assertFalse(money1.greaterThan(money2));
+  }
+
+  @Test
+  public void testGreaterThanEqual() {
+    Money money1 = Money.euros(25.50);
+    Money money2 = Money.euros(25.50);
+
+    assertFalse(money1.greaterThan(money2));
+  }
+
+  @Test
+  public void testToString() {
+    Money money = Money.euros(25.50);
+    String result = money.toString();
+
+    assertTrue(result.contains("25.50"));
+    assertTrue(result.contains("EUR"));
+    assertTrue(result.contains("|"));
+  }
+
+  @Test
+  public void testZeroAmount() {
+    Money money = Money.euros(0.00);
+    assertEquals(new BigDecimal("0.00"), money.amount());
+    assertEquals("EUR", money.getCurrencyCode());
+  }
+
+  @Test
+  public void testNegativeAmount() {
+    Money money = Money.euros(-10.50);
+    assertEquals(new BigDecimal("-10.50"), money.amount());
+    assertEquals("EUR", money.getCurrencyCode());
+  }
+
+  @Test
+  public void testVerySmallAmount() {
+    Money money = Money.euros(0.01);
+    assertEquals(new BigDecimal("0.01"), money.amount());
+    assertEquals("EUR", money.getCurrencyCode());
+  }
+
+  @Test
+  public void testConstructorWithNullCurrency() {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new Money(10.0, (Currency) null);
+        });
+  }
+
+  @Test
+  public void testConstructorWithInvalidCurrencyCode() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new Money(10.0, "INVALID");
+        });
+  }
+
+  @Test
+  public void testPrecisionWithManyDecimals() {
+    Money money = new Money(10.999999, Currency.getInstance("EUR"));
+    // Le montant devrait être arrondi selon les règles de la devise
+    assertNotNull(money.amount());
+    assertEquals("EUR", money.getCurrencyCode());
   }
 }

--- a/src/test/java/com/pecunia/api/service/TransactionServiceCreateUnitTest.java
+++ b/src/test/java/com/pecunia/api/service/TransactionServiceCreateUnitTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -11,10 +14,12 @@ import static org.mockito.Mockito.when;
 import com.pecunia.api.dto.transaction.TransactionCreateDto;
 import com.pecunia.api.mapper.TransactionMapper;
 import com.pecunia.api.model.Money;
+import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
 import com.pecunia.api.model.TransactionType;
 import com.pecunia.api.model.Wallet;
+import com.pecunia.api.repository.ProviderRepository;
 import com.pecunia.api.repository.TagRepository;
 import com.pecunia.api.repository.TransactionRepository;
 import com.pecunia.api.repository.WalletRepository;
@@ -37,6 +42,7 @@ public class TransactionServiceCreateUnitTest {
   @Mock private TagRepository tagRepository;
   @Mock private TransactionRepository transactionRepository;
   @Mock private TransactionMapper transactionMapper;
+  @Mock private ProviderRepository providerRepository;
   @InjectMocks private TransactionService transactionService;
 
   @Test
@@ -44,6 +50,7 @@ public class TransactionServiceCreateUnitTest {
     Long walletId = 1L;
     Long tagId = 1L;
     Set<Long> tagIds = Set.of(tagId);
+    final Long providerId = 1L;
 
     TransactionCreateDto createDto = new TransactionCreateDto();
     createDto.setWalletId(walletId);
@@ -51,6 +58,7 @@ public class TransactionServiceCreateUnitTest {
     createDto.setType(TransactionType.DEBIT);
     createDto.setNote("Test transaction");
     createDto.setTagsIds(tagIds);
+    createDto.setProviderId(providerId);
 
     Wallet mockWallet = new Wallet();
     mockWallet.setId(walletId);
@@ -59,6 +67,10 @@ public class TransactionServiceCreateUnitTest {
     Tag mockTag = new Tag();
     mockTag.setId(tagId);
     final Set<Tag> mockTags = Set.of(mockTag);
+
+    Provider mockProvider = new Provider();
+    mockProvider.setId(providerId);
+    mockProvider.setProviderName("test provider");
 
     Transaction mockTransaction = new Transaction();
     mockTransaction.setId(1L);
@@ -75,7 +87,8 @@ public class TransactionServiceCreateUnitTest {
     // Assert
     when(walletRepository.findById(walletId)).thenReturn(Optional.of(mockWallet));
     when(tagRepository.findAllById(tagIds)).thenReturn(List.of(mockTag));
-    when(transactionMapper.convertCreateDtoToEntity(createDto, mockWallet, mockTags))
+    when(providerRepository.findById(providerId)).thenReturn(Optional.of(mockProvider));
+    when(transactionMapper.convertCreateDtoToEntity(createDto, mockWallet, mockTags, mockProvider))
         .thenReturn(mockTransaction);
     when(transactionRepository.save(mockTransaction)).thenReturn(savedTransaction);
     when(transactionMapper.convertToCreateDto(savedTransaction)).thenReturn(expectedResult);
@@ -87,7 +100,8 @@ public class TransactionServiceCreateUnitTest {
     verify(walletRepository).findById(walletId);
     verify(tagRepository).findAllById(tagIds);
     verify(transactionRepository).save(mockTransaction);
-    verify(transactionMapper).convertCreateDtoToEntity(createDto, mockWallet, mockTags);
+    verify(transactionMapper)
+        .convertCreateDtoToEntity(createDto, mockWallet, mockTags, mockProvider);
     verify(transactionMapper).convertToCreateDto(savedTransaction);
   }
 
@@ -114,6 +128,7 @@ public class TransactionServiceCreateUnitTest {
   @Test
   void shouldCreateTransactionWithoutTags() {
     Long walletId = 1L;
+    Long providerId = 1L;
 
     TransactionCreateDto createDto = new TransactionCreateDto();
     createDto.setWalletId(walletId);
@@ -121,10 +136,15 @@ public class TransactionServiceCreateUnitTest {
     createDto.setType(TransactionType.DEBIT);
     createDto.setNote("Transaction sans tags");
     createDto.setTagsIds(null);
+    createDto.setProviderId(providerId);
 
     Wallet mockWallet = new Wallet();
     mockWallet.setId(walletId);
     mockWallet.setAmountBalance(new Money().euros(0));
+
+    Provider mockProvider = new Provider();
+    mockProvider.setId(providerId);
+    mockProvider.setProviderName("test provider");
 
     final Transaction mockTransaction = new Transaction();
     Transaction savedTransaction = new Transaction();
@@ -134,7 +154,9 @@ public class TransactionServiceCreateUnitTest {
     expectedResult.setType(TransactionType.DEBIT);
 
     when(walletRepository.findById(walletId)).thenReturn(Optional.of(mockWallet));
-    when(transactionMapper.convertCreateDtoToEntity(createDto, mockWallet, new HashSet<>()))
+    when(providerRepository.findById(providerId)).thenReturn(Optional.of(mockProvider));
+    when(transactionMapper.convertCreateDtoToEntity(
+            createDto, mockWallet, new HashSet<>(), mockProvider))
         .thenReturn(mockTransaction);
     when(transactionRepository.save(mockTransaction)).thenReturn(savedTransaction);
     when(transactionMapper.convertToCreateDto(savedTransaction)).thenReturn(expectedResult);
@@ -150,15 +172,20 @@ public class TransactionServiceCreateUnitTest {
   @Test
   void shouldCreateTransactionWithEmptyTagSet() {
     Long walletId = 1L;
+    Long providerId = 1L;
 
     TransactionCreateDto createDto = new TransactionCreateDto();
     createDto.setWalletId(walletId);
     createDto.setAmount(new Money().euros(75.00));
     createDto.setType(TransactionType.DEBIT);
     createDto.setTagsIds(new HashSet<>());
+    createDto.setProviderId(providerId);
 
     Wallet mockWallet = new Wallet();
     mockWallet.setAmountBalance(new Money().euros(10));
+    Provider mockProvider = new Provider();
+    mockProvider.setId(providerId);
+    mockProvider.setProviderName("test provider");
     final Transaction mockTransaction = new Transaction();
     final Transaction savedTransaction = new Transaction();
     TransactionCreateDto expectedResult = new TransactionCreateDto();
@@ -166,7 +193,9 @@ public class TransactionServiceCreateUnitTest {
 
     when(walletRepository.findById(walletId)).thenReturn(Optional.of(mockWallet));
     when(tagRepository.findAllById(new HashSet<>())).thenReturn(List.of());
-    when(transactionMapper.convertCreateDtoToEntity(createDto, mockWallet, new HashSet<>()))
+    when(providerRepository.findById(providerId)).thenReturn(Optional.of(mockProvider));
+    when(transactionMapper.convertCreateDtoToEntity(
+            createDto, mockWallet, new HashSet<>(), mockProvider))
         .thenReturn(mockTransaction);
     when(transactionRepository.save(mockTransaction)).thenReturn(savedTransaction);
     when(transactionMapper.convertToCreateDto(savedTransaction)).thenReturn(expectedResult);
@@ -174,12 +203,45 @@ public class TransactionServiceCreateUnitTest {
     TransactionCreateDto result = transactionService.create(createDto);
 
     assertNotNull(result);
+    verify(walletRepository).findById(walletId);
+    verify(transactionRepository).save(mockTransaction);
     verify(tagRepository).findAllById(new HashSet<>());
   }
 
-  private Tag createTag(Long id) {
-    Tag tag = new Tag();
-    tag.setId(id);
-    return tag;
+  @Test
+  void shouldCreateTransactionWithoutProvider() {
+    Long walletId = 1L;
+
+    TransactionCreateDto createDto = new TransactionCreateDto();
+    createDto.setWalletId(walletId);
+    createDto.setAmount(new Money().euros(50.00));
+    createDto.setType(TransactionType.DEBIT);
+    createDto.setNote("Transaction sans tags et provider");
+    createDto.setTagsIds(new HashSet<>());
+    createDto.setProviderId(null);
+
+    Wallet mockWallet = new Wallet();
+    mockWallet.setId(walletId);
+    mockWallet.setAmountBalance(new Money().euros(0));
+
+    final Transaction mockTransaction = new Transaction();
+    Transaction savedTransaction = new Transaction();
+    savedTransaction.setId(1L);
+
+    TransactionCreateDto expectedResult = new TransactionCreateDto();
+    expectedResult.setType(TransactionType.DEBIT);
+
+    when(walletRepository.findById(walletId)).thenReturn(Optional.of(mockWallet));
+    when(transactionMapper.convertCreateDtoToEntity(
+            eq(createDto), eq(mockWallet), anySet(), any(Provider.class)))
+        .thenReturn(mockTransaction);
+    when(transactionRepository.save(mockTransaction)).thenReturn(savedTransaction);
+    when(transactionMapper.convertToCreateDto(savedTransaction)).thenReturn(expectedResult);
+
+    TransactionCreateDto result = transactionService.create(createDto);
+
+    assertNotNull(result);
+    verify(walletRepository).findById(walletId);
+    verify(transactionRepository).save(mockTransaction);
   }
 }

--- a/src/test/java/com/pecunia/api/service/TransactionServiceUpdateIntegrationTest.java
+++ b/src/test/java/com/pecunia/api/service/TransactionServiceUpdateIntegrationTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.pecunia.api.dto.transaction.TransactionUpdateDto;
 import com.pecunia.api.model.Money;
+import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
 import com.pecunia.api.model.TransactionType;
 import com.pecunia.api.model.User;
 import com.pecunia.api.model.Wallet;
+import com.pecunia.api.repository.ProviderRepository;
 import com.pecunia.api.repository.TagRepository;
 import com.pecunia.api.repository.TransactionRepository;
 import com.pecunia.api.repository.UserRepository;
@@ -31,11 +33,13 @@ class TransactionServiceUpdateIntegrationTest {
   @Autowired private WalletRepository walletRepository;
   @Autowired private TagRepository tagRepository;
   @Autowired private UserRepository userRepository;
+  @Autowired private ProviderRepository providerRepository;
 
   private Wallet testWallet;
   private Transaction testTransaction;
   private Tag testTag;
   private User testUser;
+  private Provider providerTest;
 
   @BeforeEach
   void setUp() {
@@ -60,10 +64,16 @@ class TransactionServiceUpdateIntegrationTest {
     testTag.setTagName("TestTag");
     testTag = tagRepository.save(testTag);
 
+    providerTest = new Provider();
+    providerTest.setProviderName("testPRovider");
+    providerTest.setUser(testUser);
+    providerTest = providerRepository.save(providerTest);
+
     testTransaction = new Transaction();
     testTransaction.setAmount(new Money().euros(200.00));
     testTransaction.setType(TransactionType.DEBIT);
     testTransaction.setWallet(testWallet);
+    testTransaction.setProvider(providerTest);
     testTransaction = transactionRepository.save(testTransaction);
 
     testWallet.setAmountBalance(new Money().euros(800.00));


### PR DESCRIPTION
# Checklist

- [X] run `npm run test` or `mvn test`
- [X] les messages de commit et le nom de la pull request suivent les [Guidelines](https://github.com/Pecunia-App/.github/tree/main/profile#guidelines)

## [58](https://tree.taiga.io/project/lenny-zanotelli-pecunia/us/58?milestone=474304)

- Création endpoint providers controller
- Création methode dans le service provider controller
- Ajout de test unitaires pour renforcer la robustesse de Money
- AJout de Provider dans l'entité et les dtos de transactions
