### PR TITLE
65 - categories crud

### DIFF
--- a/src/main/java/com/pecunia/api/controller/CategoryController.java
+++ b/src/main/java/com/pecunia/api/controller/CategoryController.java
@@ -68,7 +68,7 @@ public class CategoryController {
    * @return noContent or OK
    */
   @GetMapping("/users/{userId}")
-  @CanAccessCategory
+  @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
   public ResponseEntity<Page<CategoryDto>> getAllCategoriesByUser(
       @PathVariable Long userId, Pageable pageable) {
     Page<CategoryDto> categories = categoryService.getUserCategories(userId, pageable);
@@ -98,26 +98,26 @@ public class CategoryController {
    * @param dto body à update
    * @return 200 ou 404
    */
-  @PutMapping("/{categoryId}")
+  @PutMapping("/{id}")
   @Operation(
       summary = "Update a specific Category by Id",
       description = "Role Admin require or login with correct user id.")
   @CanAccessCategory
   public ResponseEntity<CategoryUpdateDto> updateCategory(
-      @PathVariable Long categoryId, @Valid @RequestBody CategoryUpdateDto dto) {
-    CategoryUpdateDto updatedCategory = categoryService.update(categoryId, dto);
+      @PathVariable Long id, @Valid @RequestBody CategoryUpdateDto dto) {
+    CategoryUpdateDto updatedCategory = categoryService.update(id, dto);
     return updatedCategory == null
         ? ResponseEntity.notFound().build()
         : ResponseEntity.ok(updatedCategory);
   }
 
-  @DeleteMapping("/{categoryId}")
+  @DeleteMapping("/{id}")
   @Operation(
       summary = "Delete a specific Category by Id",
       description = "Role admin require or login with correct user id.")
   @CanAccessCategory
-  public ResponseEntity<Void> deleteCategory(@PathVariable Long categoryId) {
-    return categoryService.delete(categoryId)
+  public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
+    return categoryService.delete(id)
         ? ResponseEntity.noContent().build()
         : ResponseEntity.notFound().build();
   }

--- a/src/main/java/com/pecunia/api/controller/CategoryController.java
+++ b/src/main/java/com/pecunia/api/controller/CategoryController.java
@@ -1,0 +1,124 @@
+package com.pecunia.api.controller;
+
+import com.pecunia.api.dto.category.CategoryCreateDto;
+import com.pecunia.api.dto.category.CategoryDto;
+import com.pecunia.api.dto.category.CategoryUpdateDto;
+import com.pecunia.api.security.CanAccessCategory;
+import com.pecunia.api.security.HasRole;
+import com.pecunia.api.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Category Controller. */
+@RestController
+@Tag(name = "Category Controller", description = "Handle CRUD Category.")
+@RequestMapping("/categories")
+public class CategoryController {
+  @Autowired CategoryService categoryService;
+
+  /**
+   * Methode renvoyant tous les categories disponibles, utiles aux admins.
+   *
+   * @param pageable pagination
+   * @return pagination de categories
+   */
+  @GetMapping
+  @Operation(summary = "Return all categories", description = "Role admin require")
+  @HasRole("ADMIN")
+  public ResponseEntity<Page<CategoryDto>> getAllCategories(Pageable pageable) {
+    Page<CategoryDto> categories = categoryService.getAll(pageable);
+    return categories.isEmpty()
+        ? ResponseEntity.noContent().build()
+        : ResponseEntity.ok(categories);
+  }
+
+  /**
+   * Return a category by id.
+   *
+   * @param id categoryId
+   * @return notFound or ok
+   */
+  @GetMapping("/{id}")
+  @CanAccessCategory
+  public ResponseEntity<CategoryDto> getCategoryById(@PathVariable Long id) {
+    CategoryDto category = categoryService.getCategoryById(id);
+    return category == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(category);
+  }
+
+  /**
+   * Return all categories from an user.
+   *
+   * @param userId user id
+   * @param pageable pagination
+   * @return noContent or OK
+   */
+  @GetMapping("/users/{userId}")
+  @CanAccessCategory
+  public ResponseEntity<Page<CategoryDto>> getAllCategoriesByUser(
+      @PathVariable Long userId, Pageable pageable) {
+    Page<CategoryDto> categories = categoryService.getUserCategories(userId, pageable);
+    return categories.isEmpty()
+        ? ResponseEntity.noContent().build()
+        : ResponseEntity.ok(categories);
+  }
+
+  /**
+   * Create a Category.
+   *
+   * @param category categoryCreateDto
+   * @return new category or bad request
+   */
+  @PostMapping
+  @PreAuthorize("hasRole('ADMIN') or #category.userId == authentication.principal.id")
+  public ResponseEntity<CategoryCreateDto> createCategory(
+      @Valid @RequestBody CategoryCreateDto category) {
+    CategoryCreateDto savedCategory = categoryService.create(category);
+    return ResponseEntity.status(HttpStatus.CREATED).body(savedCategory);
+  }
+
+  /**
+   * Update a category.
+   *
+   * @param categoryId category id
+   * @param dto body à update
+   * @return 200 ou 404
+   */
+  @PutMapping("/{categoryId}")
+  @Operation(
+      summary = "Update a specific Category by Id",
+      description = "Role Admin require or login with correct user id.")
+  @CanAccessCategory
+  public ResponseEntity<CategoryUpdateDto> updateCategory(
+      @PathVariable Long categoryId, @Valid @RequestBody CategoryUpdateDto dto) {
+    CategoryUpdateDto updatedCategory = categoryService.update(categoryId, dto);
+    return updatedCategory == null
+        ? ResponseEntity.notFound().build()
+        : ResponseEntity.ok(updatedCategory);
+  }
+
+  @DeleteMapping("/{categoryId}")
+  @Operation(
+      summary = "Delete a specific Category by Id",
+      description = "Role admin require or login with correct user id.")
+  @CanAccessCategory
+  public ResponseEntity<Void> deleteCategory(@PathVariable Long categoryId) {
+    return categoryService.delete(categoryId)
+        ? ResponseEntity.noContent().build()
+        : ResponseEntity.notFound().build();
+  }
+}

--- a/src/main/java/com/pecunia/api/controller/ProviderController.java
+++ b/src/main/java/com/pecunia/api/controller/ProviderController.java
@@ -81,11 +81,11 @@ public class ProviderController {
     return providers.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(providers);
   }
 
-  @GetMapping("/{providerId}")
+  @GetMapping("/{id}")
   @Operation()
   @CanAccessProvider
-  public ResponseEntity<ProviderDto> getProviderById(@PathVariable Long providerId) {
-    ProviderDto provider = providerService.getProviderById(providerId);
+  public ResponseEntity<ProviderDto> getProviderById(@PathVariable Long id) {
+    ProviderDto provider = providerService.getProviderById(id);
     return provider == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(provider);
   }
 
@@ -111,26 +111,26 @@ public class ProviderController {
    * @param provider body à update
    * @return 200 ou 404
    */
-  @PutMapping("/{providerId}")
+  @PutMapping("/{id}")
   @Operation(
       summary = "Update a specific Provider by Id",
       description = "Role Admin require or login with correct user id.")
   @CanAccessProvider
   public ResponseEntity<ProviderUpdateDto> updateProvider(
-      @PathVariable Long providerId, @Valid @RequestBody ProviderUpdateDto provider) {
-    ProviderUpdateDto updatedProvider = providerService.update(providerId, provider);
+      @PathVariable Long id, @Valid @RequestBody ProviderUpdateDto provider) {
+    ProviderUpdateDto updatedProvider = providerService.update(id, provider);
     return updatedProvider == null
         ? ResponseEntity.notFound().build()
         : ResponseEntity.ok(updatedProvider);
   }
 
-  @DeleteMapping("/{providerId}")
+  @DeleteMapping("/{id}")
   @Operation(
       summary = "Delete a specific Provider by Id",
       description = "Role admin require or login with correct user id.")
   @CanAccessProvider
-  public ResponseEntity<Void> deleteProvider(@PathVariable Long providerId) {
-    return providerService.delete(providerId)
+  public ResponseEntity<Void> deleteProvider(@PathVariable Long id) {
+    return providerService.delete(id)
         ? ResponseEntity.noContent().build()
         : ResponseEntity.notFound().build();
   }

--- a/src/main/java/com/pecunia/api/controller/ProviderController.java
+++ b/src/main/java/com/pecunia/api/controller/ProviderController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -80,8 +81,23 @@ public class ProviderController {
     return providers.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(providers);
   }
 
+  @GetMapping("/{providerId}")
+  @Operation()
+  @CanAccessProvider
+  public ResponseEntity<ProviderDto> getProviderById(@PathVariable Long providerId) {
+    ProviderDto provider = providerService.getProviderById(providerId);
+    return provider == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(provider);
+  }
+
+  /**
+   * Create a Provider.
+   *
+   * @param provider providerCreateDto
+   * @return new provider or bad request
+   */
   @PostMapping
   @Operation()
+  @PreAuthorize("hasRole('ADMIN') or #provider.userId == authentication.principal.id")
   public ResponseEntity<ProviderCreateDto> createProvider(
       @Valid @RequestBody ProviderCreateDto provider) {
     ProviderCreateDto savedProvider = providerService.create(provider);

--- a/src/main/java/com/pecunia/api/controller/TagController.java
+++ b/src/main/java/com/pecunia/api/controller/TagController.java
@@ -41,7 +41,7 @@ public class TagController {
   @Operation(
       summary = "Return all tags inside a wallet id",
       description = "User id or Role Admin require")
-  @PreAuthorize("hasRole('ROLE_ADMIN') or #userId == authentication.principal.id")
+  @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
   public ResponseEntity<Page<TagDto>> getAllTagsByUser(Long userId, Pageable pageable) {
     Page<TagDto> tags = tagService.getUserTags(userId, pageable);
     return tags.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(tags);

--- a/src/main/java/com/pecunia/api/dto/category/CategoryCreateDto.java
+++ b/src/main/java/com/pecunia/api/dto/category/CategoryCreateDto.java
@@ -1,0 +1,71 @@
+package com.pecunia.api.dto.category;
+
+import com.pecunia.api.model.CategoryType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class CategoryCreateDto {
+  @NotBlank(message = "Le nom de la catégorie est obligatoire.")
+  @Size(min = 1, max = 10, message = "Le nom de la catégorie ne doit pas dépasser 10 caractères.")
+  private String categoryName;
+
+  private String icon;
+
+  @Pattern(
+      regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+      message = "La couleur doit être au format hexadécimal (ex: #FF5733 ou #F53)")
+  private String color;
+
+  private Boolean isGlobal;
+  private CategoryType type;
+  private Long userId;
+
+  public String getCategoryName() {
+    return categoryName;
+  }
+
+  public void setCategoryName(String categoryName) {
+    this.categoryName = categoryName;
+  }
+
+  public String getIcon() {
+    return icon;
+  }
+
+  public void setIcon(String icon) {
+    this.icon = icon;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
+
+  public Boolean getIsGlobal() {
+    return isGlobal;
+  }
+
+  public void setIsGlobal(Boolean isGlobal) {
+    this.isGlobal = isGlobal;
+  }
+
+  public CategoryType getType() {
+    return type;
+  }
+
+  public void setType(CategoryType type) {
+    this.type = type;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
+}

--- a/src/main/java/com/pecunia/api/dto/category/CategoryDto.java
+++ b/src/main/java/com/pecunia/api/dto/category/CategoryDto.java
@@ -1,0 +1,85 @@
+package com.pecunia.api.dto.category;
+
+import com.pecunia.api.model.CategoryType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class CategoryDto {
+  private Long id;
+
+  @NotEmpty(message = "Category name cannt be empty.")
+  @Size(min = 1, max = 10, message = "le nom de la catégorie ne doit pas dépassé 10 caractères.")
+  private String categoryName;
+
+  private String icon;
+
+  @Pattern(
+      regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+      message = "La couleur doit être au format hexadécimal (ex: #FF5733 ou #F53)")
+  private String color;
+
+  private CategoryType type;
+
+  @NotNull(message = "is_Global cannot be null")
+  private boolean isGlobal;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getCategoryName() {
+    return categoryName;
+  }
+
+  public void setCategoryName(String categoryName) {
+    this.categoryName = categoryName;
+  }
+
+  public String getIcon() {
+    return icon;
+  }
+
+  public void setIcon(String icon) {
+    this.icon = icon;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
+
+  public CategoryType getType() {
+    return type;
+  }
+
+  public void setType(CategoryType type) {
+    this.type = type;
+  }
+
+  public boolean isGlobal() {
+    return isGlobal;
+  }
+
+  public void setGlobal(boolean isGlobal) {
+    this.isGlobal = isGlobal;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
+
+  private Long userId;
+}

--- a/src/main/java/com/pecunia/api/dto/category/CategoryUpdateDto.java
+++ b/src/main/java/com/pecunia/api/dto/category/CategoryUpdateDto.java
@@ -1,0 +1,60 @@
+package com.pecunia.api.dto.category;
+
+import com.pecunia.api.model.CategoryType;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class CategoryUpdateDto {
+  @Size(min = 1, max = 10, message = "Le nom de la catégorie ne doit pas dépasser 10 caractères.")
+  private String categoryName;
+
+  private String icon;
+
+  @Pattern(
+      regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+      message = "La couleur doit être au format hexadécimal (ex: #FF5733 ou #F53)")
+  private String color;
+
+  private Boolean isGlobal;
+  private CategoryType type;
+
+  public String getCategoryName() {
+    return categoryName;
+  }
+
+  public void setCategoryName(String categoryName) {
+    this.categoryName = categoryName;
+  }
+
+  public String getIcon() {
+    return icon;
+  }
+
+  public void setIcon(String icon) {
+    this.icon = icon;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
+
+  public Boolean getIsGlobal() {
+    return isGlobal;
+  }
+
+  public void setIsGlobal(Boolean isGlobal) {
+    this.isGlobal = isGlobal;
+  }
+
+  public CategoryType getType() {
+    return type;
+  }
+
+  public void setType(CategoryType type) {
+    this.type = type;
+  }
+}

--- a/src/main/java/com/pecunia/api/dto/provider/ProviderCreateDto.java
+++ b/src/main/java/com/pecunia/api/dto/provider/ProviderCreateDto.java
@@ -9,7 +9,7 @@ public class ProviderCreateDto {
   @Size(min = 1, max = 20, message = "Le nom du fournisseur ne doit pas dépasser 20 caractères.")
   private String providerName;
 
-  @NotNull(message = "Un Wallet est toujours lié à un utilisateur.")
+  @NotNull(message = "Un Fournisseur est toujours lié à un utilisateur.")
   private Long userId;
 
   public Long getUserId() {

--- a/src/main/java/com/pecunia/api/dto/transaction/TransactionCreateDto.java
+++ b/src/main/java/com/pecunia/api/dto/transaction/TransactionCreateDto.java
@@ -1,7 +1,6 @@
 package com.pecunia.api.dto.transaction;
 
 import com.pecunia.api.model.Money;
-import com.pecunia.api.model.TransactionType;
 import com.pecunia.api.validator.PositiveMoney;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -14,8 +13,6 @@ public class TransactionCreateDto {
       message = "Le montant ne peut pas être négatif. Changer le type vers DEBIT pour du négatif.")
   private Money amount;
 
-  private TransactionType type;
-
   @Size(min = 0, max = 20, message = "La note peut contenir un maximum de 20 caractères.")
   private String note;
 
@@ -24,6 +21,7 @@ public class TransactionCreateDto {
 
   private Set<Long> tagsIds;
   private Long providerId;
+  private Long categoryId;
 
   public Long getProviderId() {
     return providerId;
@@ -39,14 +37,6 @@ public class TransactionCreateDto {
 
   public void setAmount(Money amount) {
     this.amount = amount;
-  }
-
-  public TransactionType getType() {
-    return type;
-  }
-
-  public void setType(TransactionType type) {
-    this.type = type;
   }
 
   public String getNote() {
@@ -71,5 +61,13 @@ public class TransactionCreateDto {
 
   public void setTagsIds(Set<Long> tagsIds) {
     this.tagsIds = tagsIds;
+  }
+
+  public Long getCategoryId() {
+    return categoryId;
+  }
+
+  public void setCategoryId(Long categoryId) {
+    this.categoryId = categoryId;
   }
 }

--- a/src/main/java/com/pecunia/api/dto/transaction/TransactionDto.java
+++ b/src/main/java/com/pecunia/api/dto/transaction/TransactionDto.java
@@ -1,16 +1,16 @@
 package com.pecunia.api.dto.transaction;
 
 import com.pecunia.api.dto.tag.TagDto;
+import com.pecunia.api.model.CategoryType;
 import com.pecunia.api.model.Money;
 import com.pecunia.api.model.Provider;
-import com.pecunia.api.model.TransactionType;
 import java.time.LocalDateTime;
 import java.util.Set;
 
 /** TransactionDto. */
 public class TransactionDto {
   private Long id;
-  private TransactionType type;
+  private CategoryType type;
   private String note;
   private Money amount;
   private Set<TagDto> tags;
@@ -27,11 +27,11 @@ public class TransactionDto {
     this.id = id;
   }
 
-  public TransactionType getType() {
+  public CategoryType getType() {
     return type;
   }
 
-  public void setType(TransactionType type) {
+  public void setType(CategoryType type) {
     this.type = type;
   }
 

--- a/src/main/java/com/pecunia/api/dto/transaction/TransactionDto.java
+++ b/src/main/java/com/pecunia/api/dto/transaction/TransactionDto.java
@@ -1,9 +1,9 @@
 package com.pecunia.api.dto.transaction;
 
+import com.pecunia.api.dto.provider.ProviderDto;
 import com.pecunia.api.dto.tag.TagDto;
 import com.pecunia.api.model.CategoryType;
 import com.pecunia.api.model.Money;
-import com.pecunia.api.model.Provider;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -14,7 +14,7 @@ public class TransactionDto {
   private String note;
   private Money amount;
   private Set<TagDto> tags;
-  private Provider provider;
+  private ProviderDto provider;
 
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
@@ -75,11 +75,11 @@ public class TransactionDto {
     this.tags = tags;
   }
 
-  public Provider getProvider() {
+  public ProviderDto getProvider() {
     return provider;
   }
 
-  public void setProvider(Provider provider) {
+  public void setProvider(ProviderDto provider) {
     this.provider = provider;
   }
 }

--- a/src/main/java/com/pecunia/api/dto/transaction/TransactionUpdateDto.java
+++ b/src/main/java/com/pecunia/api/dto/transaction/TransactionUpdateDto.java
@@ -2,7 +2,6 @@ package com.pecunia.api.dto.transaction;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.pecunia.api.model.Money;
-import com.pecunia.api.model.TransactionType;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.Set;
@@ -10,8 +9,6 @@ import java.util.Set;
 /** TransactionUpdateDto. */
 public class TransactionUpdateDto {
   private Money amount;
-
-  private TransactionType type;
 
   @Size(min = 0, max = 20, message = "La note peut contenir un maximum de 20 caractères.")
   private String note;
@@ -21,6 +18,7 @@ public class TransactionUpdateDto {
 
   private Set<Long> tagsIds;
   private Long providerId;
+  private Long categoryId;
 
   public Long getProviderId() {
     return providerId;
@@ -54,19 +52,19 @@ public class TransactionUpdateDto {
     this.note = note;
   }
 
-  public TransactionType getType() {
-    return type;
-  }
-
-  public void setType(TransactionType type) {
-    this.type = type;
-  }
-
   public Set<Long> getTagsIds() {
     return tagsIds;
   }
 
   public void setTagsIds(Set<Long> tagsIds) {
     this.tagsIds = tagsIds;
+  }
+
+  public Long getCategoryId() {
+    return categoryId;
+  }
+
+  public void setCategoryId(Long categoryId) {
+    this.categoryId = categoryId;
   }
 }

--- a/src/main/java/com/pecunia/api/exception/CategoryTypeNotSupportedException.java
+++ b/src/main/java/com/pecunia/api/exception/CategoryTypeNotSupportedException.java
@@ -1,12 +1,12 @@
 package com.pecunia.api.exception;
 
-public class TransactionTypeNotSupportedException extends RuntimeException {
+public class CategoryTypeNotSupportedException extends RuntimeException {
   /**
    * Transaction Type Not supported Exception.
    *
    * @param message message d'erreur
    */
-  public TransactionTypeNotSupportedException(String message) {
+  public CategoryTypeNotSupportedException(String message) {
     super(message);
   }
 }

--- a/src/main/java/com/pecunia/api/mapper/CategoryMapper.java
+++ b/src/main/java/com/pecunia/api/mapper/CategoryMapper.java
@@ -1,0 +1,55 @@
+package com.pecunia.api.mapper;
+
+import com.pecunia.api.dto.category.CategoryCreateDto;
+import com.pecunia.api.dto.category.CategoryDto;
+import com.pecunia.api.dto.category.CategoryUpdateDto;
+import com.pecunia.api.model.Category;
+import com.pecunia.api.model.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryMapper {
+  public CategoryDto convertToDto(Category category) {
+    CategoryDto dto = new CategoryDto();
+    dto.setId(category.getId());
+    dto.setCategoryName(category.getCategoryName());
+    dto.setType(category.getType());
+    dto.setColor(category.getColor());
+    dto.setIcon(category.getIcon());
+    dto.setGlobal(category.getIsGlobal());
+    dto.setUserId(category.getUser().getId());
+    return dto;
+  }
+
+  public Category convertCreateDtoToEntity(CategoryCreateDto dto, User user) {
+    Category entity = new Category();
+    entity.setCategoryName(dto.getCategoryName());
+    entity.setColor(dto.getColor());
+    entity.setType(dto.getType());
+    entity.setIcon(dto.getIcon());
+    entity.setIsGlobal(dto.getIsGlobal());
+    entity.setUser(user);
+    return entity;
+  }
+
+  public CategoryCreateDto convertToCreateDto(Category entity) {
+    CategoryCreateDto dto = new CategoryCreateDto();
+    dto.setCategoryName(entity.getCategoryName());
+    dto.setColor(entity.getColor());
+    dto.setIcon(entity.getIcon());
+    dto.setIsGlobal(entity.getIsGlobal());
+    dto.setType(entity.getType());
+    dto.setUserId(entity.getUser().getId());
+    return dto;
+  }
+
+  public CategoryUpdateDto convertToUpdateDto(Category entity) {
+    CategoryUpdateDto dto = new CategoryUpdateDto();
+    dto.setCategoryName(entity.getCategoryName());
+    dto.setColor(entity.getColor());
+    dto.setIcon(entity.getIcon());
+    dto.setIsGlobal(entity.getIsGlobal());
+    dto.setType(entity.getType());
+    return dto;
+  }
+}

--- a/src/main/java/com/pecunia/api/mapper/TransactionMapper.java
+++ b/src/main/java/com/pecunia/api/mapper/TransactionMapper.java
@@ -11,16 +11,14 @@ import com.pecunia.api.model.Transaction;
 import com.pecunia.api.model.Wallet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** TransactionMapper. */
 @Component
 public class TransactionMapper {
-  private final TagMapper tagMapper;
-
-  public TransactionMapper(TagMapper tagMapper) {
-    this.tagMapper = tagMapper;
-  }
+  @Autowired private ProviderMapper providerMapper;
+  @Autowired private TagMapper tagMapper;
 
   /**
    * @param transaction
@@ -40,7 +38,7 @@ public class TransactionMapper {
       dto.setTags(tagDtos);
     }
     if (transaction.getProvider() != null) {
-      dto.setProvider(transaction.getProvider());
+      dto.setProvider(providerMapper.convertToDto(transaction.getProvider()));
     }
     return dto;
   }

--- a/src/main/java/com/pecunia/api/mapper/TransactionMapper.java
+++ b/src/main/java/com/pecunia/api/mapper/TransactionMapper.java
@@ -4,6 +4,7 @@ import com.pecunia.api.dto.tag.TagDto;
 import com.pecunia.api.dto.transaction.TransactionCreateDto;
 import com.pecunia.api.dto.transaction.TransactionDto;
 import com.pecunia.api.dto.transaction.TransactionUpdateDto;
+import com.pecunia.api.model.Category;
 import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
@@ -30,7 +31,7 @@ public class TransactionMapper {
     dto.setId(transaction.getId());
     dto.setNote(transaction.getNote());
     dto.setAmount(transaction.getAmount());
-    dto.setType(transaction.getType());
+    dto.setType(transaction.getCategoryType());
     dto.setCreatedAt(transaction.getCreatedAt());
     dto.setUpdatedAt(transaction.getUpdatedAt());
     if (transaction.getTags() != null) {
@@ -38,23 +39,25 @@ public class TransactionMapper {
           transaction.getTags().stream().map(tagMapper::convertToDto).collect(Collectors.toSet());
       dto.setTags(tagDtos);
     }
-    dto.setProvider(transaction.getProvider());
-
+    if (transaction.getProvider() != null) {
+      dto.setProvider(transaction.getProvider());
+    }
     return dto;
   }
 
   public Transaction convertCreateDtoToEntity(
-      TransactionCreateDto dto, Wallet wallet, Set<Tag> tags, Provider provider) {
+      TransactionCreateDto dto,
+      Wallet wallet,
+      Set<Tag> tags,
+      Provider provider,
+      Category category) {
     Transaction transaction = new Transaction();
     transaction.setAmount(dto.getAmount());
     transaction.setNote(dto.getNote());
-    transaction.setType(dto.getType());
     transaction.setTags(tags);
     transaction.setWallet(wallet);
-    if (transaction.getProvider() != null) {
-      transaction.setProvider(provider);
-    }
-    transaction.setProvider(null);
+    transaction.setProvider(provider);
+    transaction.setCategory(category);
 
     return transaction;
   }
@@ -63,14 +66,16 @@ public class TransactionMapper {
     TransactionCreateDto dto = new TransactionCreateDto();
     dto.setAmount(transaction.getAmount());
     dto.setNote(transaction.getNote());
-    dto.setType(transaction.getType());
     dto.setWalletId(transaction.getWallet().getId());
     if (transaction.getTags() != null) {
       Set<Long> tagsIds =
           transaction.getTags().stream().map(Tag::getId).collect(Collectors.toSet());
       dto.setTagsIds(tagsIds);
     }
-    dto.setProviderId(transaction.getProvider().getId());
+    if (transaction.getProvider() != null) {
+      dto.setProviderId(transaction.getProvider().getId());
+    }
+    dto.setCategoryId(transaction.getCategory().getId());
 
     return dto;
   }
@@ -79,14 +84,16 @@ public class TransactionMapper {
     TransactionUpdateDto dto = new TransactionUpdateDto();
     dto.setAmount(transaction.getAmount());
     dto.setNote(transaction.getNote());
-    dto.setType(transaction.getType());
     dto.setCreatedAt(transaction.getCreatedAt());
     if (transaction.getTags() != null) {
       Set<Long> tagsIds =
           transaction.getTags().stream().map(Tag::getId).collect(Collectors.toSet());
       dto.setTagsIds(tagsIds);
     }
-    dto.setProviderId(transaction.getProvider().getId());
+    if (transaction.getProvider() != null) {
+      dto.setProviderId(transaction.getProvider().getId());
+    }
+    dto.setCategoryId(transaction.getCategory().getId());
 
     return dto;
   }
@@ -95,7 +102,6 @@ public class TransactionMapper {
     Transaction transaction = new Transaction();
     transaction.setAmount(dto.getAmount());
     transaction.setNote(dto.getNote());
-    transaction.setType(dto.getType());
 
     return transaction;
   }

--- a/src/main/java/com/pecunia/api/model/Category.java
+++ b/src/main/java/com/pecunia/api/model/Category.java
@@ -1,0 +1,109 @@
+package com.pecunia.api.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Category Entity. */
+@Entity
+@Table(name = "category")
+public class Category extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "category_name", nullable = false)
+  private String categoryName;
+
+  @Column(nullable = false)
+  private String icon;
+
+  @Column(nullable = false)
+  private String color;
+
+  @Column private CategoryType type;
+
+  @Column(name = "is_global")
+  private Boolean isGlobal;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private Set<Transaction> transactions = new HashSet<>();
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getCategoryName() {
+    return categoryName;
+  }
+
+  public void setCategoryName(String categoryName) {
+    this.categoryName = categoryName;
+  }
+
+  public String getIcon() {
+    return icon;
+  }
+
+  public void setIcon(String icon) {
+    this.icon = icon;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
+
+  public CategoryType getType() {
+    return type;
+  }
+
+  public void setType(CategoryType type) {
+    this.type = type;
+  }
+
+  public Boolean getIsGlobal() {
+    return isGlobal;
+  }
+
+  public void setIsGlobal(Boolean isGlobal) {
+    this.isGlobal = isGlobal;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public void setUser(User user) {
+    this.user = user;
+  }
+
+  public Set<Transaction> getTransactions() {
+    return transactions;
+  }
+
+  public void setTransactions(Set<Transaction> transactions) {
+    this.transactions = transactions;
+  }
+}

--- a/src/main/java/com/pecunia/api/model/CategoryType.java
+++ b/src/main/java/com/pecunia/api/model/CategoryType.java
@@ -1,0 +1,7 @@
+package com.pecunia.api.model;
+
+/** CategoryType. */
+public enum CategoryType {
+  DEBIT,
+  CREDIT
+}

--- a/src/main/java/com/pecunia/api/model/Money.java
+++ b/src/main/java/com/pecunia/api/model/Money.java
@@ -181,7 +181,7 @@ public class Money implements Comparable<Money> {
    * @return le résultat de la soustraction
    * @throws CannotAddTwoCurrenciesException si les devises sont différentes
    */
-  public Money substract(final Money other) {
+  public Money subtract(final Money other) {
     validateSameCurrency(other);
     return newMoney(amount - other.amount);
   }

--- a/src/main/java/com/pecunia/api/model/Transaction.java
+++ b/src/main/java/com/pecunia/api/model/Transaction.java
@@ -27,7 +27,6 @@ public class Transaction extends BaseEntity {
   @Column
   private Money amount;
 
-  @Column private TransactionType type;
   @Column private String note;
 
   @ManyToOne(fetch = FetchType.EAGER)
@@ -44,6 +43,18 @@ public class Transaction extends BaseEntity {
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "provider_id")
   private Provider provider;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "category_id")
+  private Category category;
+
+  public Category getCategory() {
+    return category;
+  }
+
+  public void setCategory(Category category) {
+    this.category = category;
+  }
 
   public Provider getProvider() {
     return provider;
@@ -85,19 +96,15 @@ public class Transaction extends BaseEntity {
     this.wallet = wallet;
   }
 
-  public TransactionType getType() {
-    return type;
-  }
-
-  public void setType(TransactionType type) {
-    this.type = type;
-  }
-
   public String getNote() {
     return note;
   }
 
   public void setNote(String note) {
     this.note = note;
+  }
+
+  public CategoryType getCategoryType() {
+    return category.getType();
   }
 }

--- a/src/main/java/com/pecunia/api/model/TransactionType.java
+++ b/src/main/java/com/pecunia/api/model/TransactionType.java
@@ -1,7 +1,0 @@
-package com.pecunia.api.model;
-
-/** TransactionType. */
-public enum TransactionType {
-  DEBIT,
-  CREDIT
-}

--- a/src/main/java/com/pecunia/api/model/User.java
+++ b/src/main/java/com/pecunia/api/model/User.java
@@ -74,7 +74,26 @@ public class User extends BaseEntity implements UserDetails {
   private Wallet wallet;
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private Set<Category> categories = new HashSet<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private Set<Provider> providers = new HashSet<>();
+
+  public Set<Provider> getProviders() {
+    return providers;
+  }
+
+  public void setProviders(Set<Provider> providers) {
+    this.providers = providers;
+  }
+
+  public Set<Category> getCategories() {
+    return categories;
+  }
+
+  public void setCategories(Set<Category> categories) {
+    this.categories = categories;
+  }
 
   public Wallet getWallet() {
     return wallet;

--- a/src/main/java/com/pecunia/api/repository/CategoryRepository.java
+++ b/src/main/java/com/pecunia/api/repository/CategoryRepository.java
@@ -1,0 +1,13 @@
+package com.pecunia.api.repository;
+
+import com.pecunia.api.model.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** CategoryRepository. */
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+  Page<Category> findByUserId(Long userId, Pageable pageable);
+
+  boolean existsByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/com/pecunia/api/repository/TransactionRepository.java
+++ b/src/main/java/com/pecunia/api/repository/TransactionRepository.java
@@ -21,6 +21,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 
   Page<Transaction> findByWalletIdAndCreatedAtBetween(
       Long walletId, Pageable pageable, LocalDateTime from, LocalDateTime to);
+
   List<Transaction> findByCategoryId(Long categoryId);
 
   boolean existsByIdAndWalletUserId(Long id, Long walletUserId);

--- a/src/main/java/com/pecunia/api/repository/TransactionRepository.java
+++ b/src/main/java/com/pecunia/api/repository/TransactionRepository.java
@@ -2,6 +2,7 @@ package com.pecunia.api.repository;
 
 import com.pecunia.api.model.Transaction;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,6 +21,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 
   Page<Transaction> findByWalletIdAndCreatedAtBetween(
       Long walletId, Pageable pageable, LocalDateTime from, LocalDateTime to);
+  List<Transaction> findByCategoryId(Long categoryId);
 
   boolean existsByIdAndWalletUserId(Long id, Long walletUserId);
 }

--- a/src/main/java/com/pecunia/api/security/CanAccessCategory.java
+++ b/src/main/java/com/pecunia/api/security/CanAccessCategory.java
@@ -1,0 +1,12 @@
+package com.pecunia.api.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('ADMIN') or @authz.isOwner(#id, 'category')")
+public @interface CanAccessCategory {}

--- a/src/main/java/com/pecunia/api/security/SecurityExpressions.java
+++ b/src/main/java/com/pecunia/api/security/SecurityExpressions.java
@@ -1,6 +1,7 @@
 package com.pecunia.api.security;
 
 import com.pecunia.api.model.User;
+import com.pecunia.api.repository.CategoryRepository;
 import com.pecunia.api.repository.ProviderRepository;
 import com.pecunia.api.repository.TransactionRepository;
 import com.pecunia.api.repository.UserRepository;
@@ -16,16 +17,19 @@ public class SecurityExpressions {
   private final WalletRepository walletRepository;
   private final UserRepository userRepository;
   private final ProviderRepository providerRepository;
+  private final CategoryRepository categoryRepository;
 
   public SecurityExpressions(
       TransactionRepository transactionRepository,
       WalletRepository walletRepository,
       UserRepository userRepository,
-      ProviderRepository providerRepository) {
+      ProviderRepository providerRepository,
+      CategoryRepository categoryRepository) {
     this.transactionRepository = transactionRepository;
     this.walletRepository = walletRepository;
     this.userRepository = userRepository;
     this.providerRepository = providerRepository;
+    this.categoryRepository = categoryRepository;
   }
 
   /**
@@ -42,6 +46,7 @@ public class SecurityExpressions {
           transactionRepository.existsByIdAndWalletUserId(resourceId, currentUserId);
       case "wallet" -> walletRepository.existsByIdAndUserId(resourceId, currentUserId);
       case "provider" -> providerRepository.existsByIdAndUserId(resourceId, currentUserId);
+      case "category" -> categoryRepository.existsByIdAndUserId(resourceId, currentUserId);
       default -> throw new IllegalArgumentException("Uknown resource type: " + resourceType);
     };
   }

--- a/src/main/java/com/pecunia/api/security/SecurityExpressions.java
+++ b/src/main/java/com/pecunia/api/security/SecurityExpressions.java
@@ -35,8 +35,8 @@ public class SecurityExpressions {
   /**
    * Méthode pour voir si l'utilisateur peut accéder à une ressource.
    *
-   * @param resourceId id of wallet or transaction
-   * @param resourceType wallet or transaction
+   * @param resourceId id of wallet, provider, category or, transaction
+   * @param resourceType wallet, provider, category, transaction
    * @return boolean
    */
   public boolean isOwner(Long resourceId, String resourceType) {

--- a/src/main/java/com/pecunia/api/service/CategoryService.java
+++ b/src/main/java/com/pecunia/api/service/CategoryService.java
@@ -1,0 +1,118 @@
+package com.pecunia.api.service;
+
+import com.pecunia.api.dto.category.CategoryCreateDto;
+import com.pecunia.api.dto.category.CategoryDto;
+import com.pecunia.api.dto.category.CategoryUpdateDto;
+import com.pecunia.api.exception.ResourceNotFoundException;
+import com.pecunia.api.mapper.CategoryMapper;
+import com.pecunia.api.model.Category;
+import com.pecunia.api.model.CategoryType;
+import com.pecunia.api.model.User;
+import com.pecunia.api.repository.CategoryRepository;
+import com.pecunia.api.repository.UserRepository;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategoryService {
+  @Autowired CategoryRepository categoryRepository;
+  @Autowired UserRepository userRepository;
+  @Autowired CategoryMapper categoryMapper;
+  @Autowired TransactionService transactionService;
+
+  public Page<CategoryDto> getAll(@ParameterObject Pageable pageable) {
+    Page<Category> categories = categoryRepository.findAll(pageable);
+    return categories.map(categoryMapper::convertToDto);
+  }
+
+  public Page<CategoryDto> getUserCategories(Long userId, Pageable pageable) {
+    Page<Category> categories = categoryRepository.findByUserId(userId, pageable);
+    return categories.map(categoryMapper::convertToDto);
+  }
+
+  public CategoryDto getCategoryById(Long categoryId) {
+    Category category = getCategoryByIdOrThrow(categoryId);
+    return category != null ? categoryMapper.convertToDto(category) : null;
+  }
+
+  public CategoryCreateDto create(CategoryCreateDto dto) {
+    validateCategoryCreation(dto);
+    User user =
+        userRepository
+            .findById(dto.getUserId())
+            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    Category category = categoryMapper.convertCreateDtoToEntity(dto, user);
+    Category savedCategory = categoryRepository.save(category);
+    return categoryMapper.convertToCreateDto(savedCategory);
+  }
+
+  public CategoryUpdateDto update(Long categoryId, CategoryUpdateDto dto) {
+    Category category = getCategoryByIdOrThrow(categoryId);
+    CategoryType oldType = category.getType();
+
+    if (dto.getCategoryName() != null) {
+      category.setCategoryName(dto.getCategoryName().trim());
+    }
+    if (dto.getIcon() != null) {
+      category.setIcon(dto.getIcon());
+    }
+    if (dto.getIsGlobal() != null) {
+      category.setIsGlobal(dto.getIsGlobal());
+    }
+    if (dto.getColor() != null) {
+      category.setColor(dto.getColor());
+    }
+
+    boolean typeChanged = false;
+    if (dto.getType() != null && !dto.getType().equals(oldType)) {
+      category.setType(dto.getType());
+      typeChanged = true;
+    }
+
+    Category updatedCategory = categoryRepository.save(category);
+    if (typeChanged) {
+      transactionService.recalculateWalletBalancesForCategoryTypeChange(
+          categoryId, oldType, dto.getType());
+    }
+    return categoryMapper.convertToUpdateDto(updatedCategory);
+  }
+
+  public boolean delete(Long categoryId) {
+    Category category = getCategoryByIdOrThrow(categoryId);
+    if (category == null) {
+      return false;
+    }
+    categoryRepository.delete(category);
+    return true;
+  }
+
+  private static void validateCategoryCreation(CategoryCreateDto dto) {
+    if (dto.getCategoryName() == null) {
+      throw new IllegalArgumentException("Category name cannot be null.");
+    }
+    if (dto.getType() == null) {
+      throw new IllegalArgumentException("CategoryType cannot be null.");
+    }
+    if (dto.getIsGlobal() == null) {
+      throw new IllegalArgumentException("isGLobal cannot be null.");
+    }
+    if (dto.getColor() == null) {
+      throw new IllegalArgumentException("Category color cannot be null.");
+    }
+    if (dto.getUserId() == null) {
+      throw new IllegalArgumentException("User id cannot be null");
+    }
+  }
+
+  private Category getCategoryByIdOrThrow(Long categoryId) {
+    return categoryRepository
+        .findById(categoryId)
+        .orElseThrow(
+            () ->
+                new ResourceNotFoundException(
+                    "la categorie avec l'id" + categoryId + "n'a pas été trouvée."));
+  }
+}

--- a/src/main/java/com/pecunia/api/service/ProviderService.java
+++ b/src/main/java/com/pecunia/api/service/ProviderService.java
@@ -47,6 +47,11 @@ public class ProviderService {
     return providers.map(providerMapper::convertToDto);
   }
 
+  public ProviderDto getProviderById(Long providerId) {
+    Provider provider = getProviderByIdOrThrow(providerId);
+    return provider != null ? providerMapper.convertToDto(provider) : null;
+  }
+
   public ProviderCreateDto create(ProviderCreateDto providerCreateDto) {
     validateProviderCreation(providerCreateDto);
     User user =

--- a/src/main/java/com/pecunia/api/service/TransactionService.java
+++ b/src/main/java/com/pecunia/api/service/TransactionService.java
@@ -3,21 +3,24 @@ package com.pecunia.api.service;
 import com.pecunia.api.dto.transaction.TransactionCreateDto;
 import com.pecunia.api.dto.transaction.TransactionDto;
 import com.pecunia.api.dto.transaction.TransactionUpdateDto;
+import com.pecunia.api.exception.CategoryTypeNotSupportedException;
 import com.pecunia.api.exception.ResourceNotFoundException;
-import com.pecunia.api.exception.TransactionTypeNotSupportedException;
 import com.pecunia.api.mapper.TransactionMapper;
+import com.pecunia.api.model.Category;
+import com.pecunia.api.model.CategoryType;
 import com.pecunia.api.model.Money;
 import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
-import com.pecunia.api.model.TransactionType;
 import com.pecunia.api.model.Wallet;
+import com.pecunia.api.repository.CategoryRepository;
 import com.pecunia.api.repository.ProviderRepository;
 import com.pecunia.api.repository.TagRepository;
 import com.pecunia.api.repository.TransactionRepository;
 import com.pecunia.api.repository.WalletRepository;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,8 +63,9 @@ public class TransactionService {
     if (transactionCreateDto.getWalletId() == null) {
       throw new IllegalArgumentException("WalletId cannot be null.");
     }
-    if (transactionCreateDto.getType() == null) {
-      throw new TransactionTypeNotSupportedException("Transaction Type cannot be null.");
+
+    if (transactionCreateDto.getCategoryId() == null) {
+      throw new IllegalArgumentException("categoryId cannot be null.");
     }
   }
 
@@ -73,7 +77,7 @@ public class TransactionService {
    */
   public TransactionCreateDto create(TransactionCreateDto transactionCreateDto) {
     validateTransaction(transactionCreateDto);
-    Wallet wallet =
+    final Wallet wallet =
         walletRepository
             .findById(transactionCreateDto.getWalletId())
             .orElseThrow(() -> new IllegalArgumentException("Wallet not found"));
@@ -85,49 +89,24 @@ public class TransactionService {
         throw new IllegalArgumentException("Certains tags n'existents pas.");
       }
     }
-    Provider provider = new Provider();
+    Provider provider = null;
     if (transactionCreateDto.getProviderId() != null) {
       provider =
           providerRepository
               .findById(transactionCreateDto.getProviderId())
               .orElseThrow(() -> new IllegalArgumentException("Provider not found"));
     }
+    Category category =
+        categoryRepository
+            .findById(transactionCreateDto.getCategoryId())
+            .orElseThrow(() -> new IllegalArgumentException("Category not found."));
+
     Transaction transaction =
-        transactionMapper.convertCreateDtoToEntity(transactionCreateDto, wallet, tags, provider);
+        transactionMapper.convertCreateDtoToEntity(
+            transactionCreateDto, wallet, tags, provider, category);
     Transaction savedTransaction = transactionRepository.save(transaction);
-    updateWalletBalance(wallet, transactionCreateDto.getAmount(), transactionCreateDto.getType());
+    updateWalletBalance(wallet, transactionCreateDto.getAmount(), category.getType());
     return transactionMapper.convertToCreateDto(savedTransaction);
-  }
-
-  private void updateWalletBalance(Wallet wallet, Money amount, TransactionType type) {
-    Money currentBalance = wallet.getAmountBalance();
-    Money newBalance;
-
-    switch (type) {
-      case CREDIT:
-        newBalance = currentBalance.add(amount);
-        break;
-      case DEBIT:
-        newBalance = currentBalance.substract(amount);
-        break;
-      default:
-        throw new IllegalArgumentException("Transaction type not supported: " + type);
-    }
-
-    wallet.setAmountBalance(newBalance);
-    wallet.setUpdatedAt(LocalDateTime.now());
-    walletRepository.save(wallet);
-  }
-
-  private Money reverseTransactionImpact(Money balance, Money amount, TransactionType type) {
-    switch (type) {
-      case CREDIT:
-        return balance.substract(amount);
-      case DEBIT:
-        return balance.add(amount);
-      default:
-        throw new TransactionTypeNotSupportedException("Transaction type not supported: " + type);
-    }
   }
 
   /**
@@ -141,16 +120,13 @@ public class TransactionService {
     Transaction transaction = getTransactionByIdOrThrow(id);
 
     final Money oldAmount = transaction.getAmount();
-    final TransactionType oldType = transaction.getType();
+    final CategoryType oldType = transaction.getCategoryType();
 
     if (transactionUpdateDto.getAmount() != null) {
       transaction.setAmount(transactionUpdateDto.getAmount());
     }
     if (transactionUpdateDto.getNote() != null) {
       transaction.setNote(transactionUpdateDto.getNote());
-    }
-    if (transactionUpdateDto.getType() != null) {
-      transaction.setType(transactionUpdateDto.getType());
     }
     if (transactionUpdateDto.getCreatedAt() != null) {
       transaction.setCreatedAt(transactionUpdateDto.getCreatedAt());
@@ -163,13 +139,21 @@ public class TransactionService {
       }
       transaction.setTags(newTags);
     }
-    Provider newProvider = new Provider();
+    Provider newProvider = null;
     if (transactionUpdateDto.getProviderId() != null) {
       newProvider =
           providerRepository
               .findById(transactionUpdateDto.getProviderId())
               .orElseThrow(() -> new IllegalArgumentException("Provider n'existe pas."));
       transaction.setProvider(newProvider);
+    }
+
+    if (transactionUpdateDto.getCategoryId() != null) {
+      Category newCategory =
+          categoryRepository
+              .findById(transactionUpdateDto.getCategoryId())
+              .orElseThrow(() -> new IllegalArgumentException("Category doesnt exist."));
+      transaction.setCategory(newCategory);
     }
 
     transaction.setUpdatedAt(LocalDateTime.now());
@@ -183,7 +167,8 @@ public class TransactionService {
         reverseTransactionImpact(wallet.getAmountBalance(), oldAmount, oldType);
     wallet.setAmountBalance(balanceAfterReversal);
 
-    updateWalletBalance(wallet, updatedTransaction.getAmount(), updatedTransaction.getType());
+    updateWalletBalance(
+        wallet, updatedTransaction.getAmount(), updatedTransaction.getCategoryType());
 
     return transactionMapper.convertToUpdateDto(updatedTransaction);
   }
@@ -206,12 +191,45 @@ public class TransactionService {
 
     Money currentBalance = wallet.getAmountBalance();
     Money balanceAfterDeletion =
-        reverseTransactionImpact(currentBalance, transaction.getAmount(), transaction.getType());
+        reverseTransactionImpact(
+            currentBalance, transaction.getAmount(), transaction.getCategoryType());
     wallet.setAmountBalance(balanceAfterDeletion);
     wallet.setUpdatedAt(LocalDateTime.now());
 
     transactionRepository.delete(transaction);
     return true;
+  }
+
+  private void updateWalletBalance(Wallet wallet, Money amount, CategoryType type) {
+    Money currentBalance = wallet.getAmountBalance();
+    Money newBalance;
+
+    switch (type) {
+      case CREDIT:
+        newBalance = currentBalance.add(amount);
+        break;
+      case DEBIT:
+        newBalance = currentBalance.subtract(amount);
+        break;
+      default:
+        throw new IllegalArgumentException("Transaction type not supported: " + type);
+    }
+
+    wallet.setAmountBalance(newBalance);
+    wallet.setUpdatedAt(LocalDateTime.now());
+
+    walletRepository.save(wallet);
+  }
+
+  private Money reverseTransactionImpact(Money balance, Money amount, CategoryType type) {
+    switch (type) {
+      case CREDIT:
+        return balance.subtract(amount);
+      case DEBIT:
+        return balance.add(amount);
+      default:
+        throw new CategoryTypeNotSupportedException("Category type not supported: " + type);
+    }
   }
 
   /**
@@ -254,5 +272,20 @@ public class TransactionService {
                     new ResourceNotFoundException(
                         "La transaction avec l'id " + id + " n'a pas été trouvé."));
     return transaction;
+  }
+
+  public void recalculateWalletBalancesForCategoryTypeChange(
+      Long categoryId, CategoryType oldType, CategoryType newType) {
+    List<Transaction> transactions = transactionRepository.findByCategoryId(categoryId);
+
+    for (Transaction transaction : transactions) {
+      Wallet wallet = transaction.getWallet();
+      Money amount = transaction.getAmount();
+
+      Money balanceAfterReversal =
+          reverseTransactionImpact(wallet.getAmountBalance(), amount, oldType);
+      wallet.setAmountBalance(balanceAfterReversal);
+      updateWalletBalance(wallet, amount, newType);
+    }
   }
 }

--- a/src/main/java/com/pecunia/api/service/TransactionService.java
+++ b/src/main/java/com/pecunia/api/service/TransactionService.java
@@ -13,6 +13,7 @@ import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
 import com.pecunia.api.model.Wallet;
+import com.pecunia.api.repository.CategoryRepository;
 import com.pecunia.api.repository.ProviderRepository;
 import com.pecunia.api.repository.TagRepository;
 import com.pecunia.api.repository.TransactionRepository;
@@ -35,6 +36,7 @@ public class TransactionService {
   @Autowired private WalletRepository walletRepository;
   @Autowired private TagRepository tagRepository;
   @Autowired private ProviderRepository providerRepository;
+  @Autowired private CategoryRepository categoryRepository;
 
   /**
    * Methode renvoyant toutes les transactions disponibles, utiles aux admins.

--- a/src/main/java/com/pecunia/api/service/TransactionService.java
+++ b/src/main/java/com/pecunia/api/service/TransactionService.java
@@ -13,7 +13,6 @@ import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
 import com.pecunia.api.model.Wallet;
-import com.pecunia.api.repository.CategoryRepository;
 import com.pecunia.api.repository.ProviderRepository;
 import com.pecunia.api.repository.TagRepository;
 import com.pecunia.api.repository.TransactionRepository;

--- a/src/test/java/com/pecunia/api/MoneyTest.java
+++ b/src/test/java/com/pecunia/api/MoneyTest.java
@@ -130,24 +130,24 @@ public class MoneyTest {
   }
 
   @Test
-  public void testSubstractWithSameCurrency() {
+  public void testSubtractWithSameCurrency() {
     Money money1 = Money.euros(15.75);
     Money money2 = Money.euros(5.25);
-    Money result = money1.substract(money2);
+    Money result = money1.subtract(money2);
 
     assertEquals(Money.euros(10.50), result);
     assertEquals("EUR", result.getCurrencyCode());
   }
 
   @Test
-  public void testSubstractWithDifferentCurrencies() {
+  public void testSubtractWithDifferentCurrencies() {
     Money euros = Money.euros(15.75);
     Money dollars = Money.dollars(5.25);
 
     assertThrows(
         CannotAddTwoCurrenciesException.class,
         () -> {
-          euros.substract(dollars);
+          euros.subtract(dollars);
         });
   }
 

--- a/src/test/java/com/pecunia/api/builder/CategoryFactory.java
+++ b/src/test/java/com/pecunia/api/builder/CategoryFactory.java
@@ -1,0 +1,63 @@
+package com.pecunia.api.builder;
+
+import com.pecunia.api.model.Category;
+import com.pecunia.api.model.CategoryType;
+import com.pecunia.api.model.User;
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+public class CategoryFactory {
+  public static CategoryBuilder category() {
+    return new CategoryBuilder();
+  }
+
+  public static class CategoryBuilder {
+    private Category category = new Category();
+    private User user;
+
+    public CategoryBuilder withName(String name) {
+      category.setCategoryName(name);
+      return this;
+    }
+
+    public CategoryBuilder withIcon(String icon) {
+      category.setIcon(icon);
+      return this;
+    }
+
+    public CategoryBuilder withColor(String color) {
+      category.setColor(color);
+      return this;
+    }
+
+    public CategoryBuilder withType(CategoryType type) {
+      category.setType(type);
+      return this;
+    }
+
+    public CategoryBuilder isGlobal(boolean isGlobal) {
+      category.setIsGlobal(isGlobal);
+      return this;
+    }
+
+    public CategoryBuilder withUser(User user) {
+      this.user = user;
+      return this;
+    }
+
+    public Category build(TestEntityManager entityManager) {
+      if (user == null) {
+        throw new IllegalStateException(
+            "Category muste have an user. Use 'withUser() static method.");
+      }
+      category.setUser(user);
+      Set<Category> categories = user.getCategories();
+      if (categories == null) {
+        categories = new HashSet<>();
+        user.setCategories(categories);
+      }
+      return entityManager.persistAndFlush(category);
+    }
+  }
+}

--- a/src/test/java/com/pecunia/api/builder/TransactionFactory.java
+++ b/src/test/java/com/pecunia/api/builder/TransactionFactory.java
@@ -1,8 +1,8 @@
 package com.pecunia.api.builder;
 
+import com.pecunia.api.model.Category;
 import com.pecunia.api.model.Money;
 import com.pecunia.api.model.Transaction;
-import com.pecunia.api.model.TransactionType;
 import com.pecunia.api.model.Wallet;
 import java.util.HashSet;
 import java.util.Set;
@@ -16,9 +16,10 @@ public class TransactionFactory {
   public static class TransactionBuilder {
     private Transaction transaction = new Transaction();
     private Wallet wallet;
+    private Category category;
 
-    public TransactionBuilder withType(TransactionType type) {
-      transaction.setType(type);
+    public TransactionBuilder withCategory(Category category) {
+      transaction.setCategory(category);
       return this;
     }
 

--- a/src/test/java/com/pecunia/api/service/TransactionServiceUpdateIntegrationTest.java
+++ b/src/test/java/com/pecunia/api/service/TransactionServiceUpdateIntegrationTest.java
@@ -4,13 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.pecunia.api.dto.transaction.TransactionUpdateDto;
+import com.pecunia.api.model.Category;
+import com.pecunia.api.model.CategoryType;
 import com.pecunia.api.model.Money;
 import com.pecunia.api.model.Provider;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
-import com.pecunia.api.model.TransactionType;
 import com.pecunia.api.model.User;
 import com.pecunia.api.model.Wallet;
+import com.pecunia.api.repository.CategoryRepository;
 import com.pecunia.api.repository.ProviderRepository;
 import com.pecunia.api.repository.TagRepository;
 import com.pecunia.api.repository.TransactionRepository;
@@ -34,15 +36,19 @@ class TransactionServiceUpdateIntegrationTest {
   @Autowired private TagRepository tagRepository;
   @Autowired private UserRepository userRepository;
   @Autowired private ProviderRepository providerRepository;
+  @Autowired private CategoryRepository categoryRepository;
+  @Autowired private CategoryService categoryService;
 
   private Wallet testWallet;
   private Transaction testTransaction;
   private Tag testTag;
   private User testUser;
-  private Provider providerTest;
+  private Provider testProvider;
+  private Category testCategory;
 
   @BeforeEach
   void setUp() {
+    new Money();
     testUser = new User();
     testUser.setEmail("test@test.fr");
     testUser.setLastname("lastname");
@@ -50,7 +56,7 @@ class TransactionServiceUpdateIntegrationTest {
     testUser = userRepository.save(testUser);
 
     testWallet = new Wallet();
-    testWallet.setAmountBalance(new Money().euros(1000.00));
+    testWallet.setAmountBalance(Money.euros(1000.00));
     testWallet.setName("test wallet");
     testWallet.setUser(testUser);
     testWallet = walletRepository.save(testWallet);
@@ -64,46 +70,63 @@ class TransactionServiceUpdateIntegrationTest {
     testTag.setTagName("TestTag");
     testTag = tagRepository.save(testTag);
 
-    providerTest = new Provider();
-    providerTest.setProviderName("testPRovider");
-    providerTest.setUser(testUser);
-    providerTest = providerRepository.save(providerTest);
+    testProvider = new Provider();
+    testProvider.setProviderName("testPRovider");
+    testProvider.setUser(testUser);
+    testProvider = providerRepository.save(testProvider);
+
+    testCategory = new Category();
+    testCategory.setCategoryName("testCategoryname");
+    testCategory.setUser(testUser);
+    testCategory.setType(CategoryType.DEBIT);
+    testCategory.setIsGlobal(false);
+    testCategory.setIcon("icon");
+    testCategory.setColor("white");
+    testCategory = categoryRepository.save(testCategory);
 
     testTransaction = new Transaction();
-    testTransaction.setAmount(new Money().euros(200.00));
-    testTransaction.setType(TransactionType.DEBIT);
+    testTransaction.setAmount(Money.euros(200.00));
     testTransaction.setWallet(testWallet);
-    testTransaction.setProvider(providerTest);
+    testTransaction.setProvider(testProvider);
+    testTransaction.setCategory(testCategory);
     testTransaction = transactionRepository.save(testTransaction);
 
-    testWallet.setAmountBalance(new Money().euros(800.00));
+    testWallet.setAmountBalance(Money.euros(800.00));
     testWallet = walletRepository.save(testWallet);
   }
 
   @Test
   void shouldUpdateAmountAndRecalculateBalance() {
     TransactionUpdateDto updateDto = new TransactionUpdateDto();
-    updateDto.setAmount(new Money().euros(300.00));
+    updateDto.setAmount(Money.euros(300.00));
 
     transactionService.update(testTransaction.getId(), updateDto);
     Wallet updatedWallet = walletRepository.findById(testWallet.getId()).get();
-    Money expectedBalance = new Money().euros(700.00);
+    Money expectedBalance = Money.euros(700.00);
     // Calcul = 800 + 200 - 300 = 700
     assertEquals(expectedBalance, updatedWallet.getAmountBalance());
   }
 
   @Test
-  void shouldUpdateTypeAndRecalculateBalance() {
-    TransactionUpdateDto updateDto = new TransactionUpdateDto();
-    updateDto.setType(TransactionType.CREDIT);
+  void shouldUpdateCategoryTypeAndRecalculateBalance() {
+    Category creditCategory = new Category();
+    creditCategory.setCategoryName("Credit Category");
+    creditCategory.setUser(testUser);
+    creditCategory.setType(CategoryType.CREDIT);
+    creditCategory.setIsGlobal(false);
+    creditCategory.setIcon("icon");
+    creditCategory.setColor("blue");
+    creditCategory = categoryRepository.save(creditCategory);
 
+    TransactionUpdateDto updateDto = new TransactionUpdateDto();
+    updateDto.setCategoryId(creditCategory.getId());
     transactionService.update(testTransaction.getId(), updateDto);
 
     Wallet updatedWallet = walletRepository.findById(testWallet.getId()).get();
     Transaction updatedTransaction = transactionRepository.findById(testTransaction.getId()).get();
-    assertEquals(TransactionType.CREDIT, updatedTransaction.getType());
+    assertEquals(CategoryType.CREDIT, updatedTransaction.getCategoryType());
     // Calcul = 800 + 200 + 200 = 1200
-    assertEquals(new Money().euros(1200), updatedWallet.getAmountBalance());
+    assertEquals(Money.euros(1200), updatedWallet.getAmountBalance());
   }
 
   @Test

--- a/src/test/java/com/pecunia/api/service/TransactionServiceUpdateUnitTest.java
+++ b/src/test/java/com/pecunia/api/service/TransactionServiceUpdateUnitTest.java
@@ -9,11 +9,13 @@ import static org.mockito.Mockito.when;
 import com.pecunia.api.dto.transaction.TransactionUpdateDto;
 import com.pecunia.api.exception.ResourceNotFoundException;
 import com.pecunia.api.mapper.TransactionMapper;
+import com.pecunia.api.model.Category;
+import com.pecunia.api.model.CategoryType;
 import com.pecunia.api.model.Money;
 import com.pecunia.api.model.Tag;
 import com.pecunia.api.model.Transaction;
-import com.pecunia.api.model.TransactionType;
 import com.pecunia.api.model.Wallet;
+import com.pecunia.api.repository.CategoryRepository;
 import com.pecunia.api.repository.TagRepository;
 import com.pecunia.api.repository.TransactionRepository;
 import com.pecunia.api.repository.WalletRepository;
@@ -37,23 +39,31 @@ class TransactionServiceUpdateUnitTest {
   @Mock private WalletRepository walletRepository;
   @Mock private TagRepository tagRepository;
   @Mock private TransactionMapper transactionMapper;
+  @Mock private CategoryRepository categoryRepository;
 
   @InjectMocks private TransactionService transactionService;
 
   private Transaction mockTransaction;
   private Wallet mockWallet;
+  private Category mockCategory;
 
   @BeforeEach
   void setup() {
+    new Money();
     mockWallet = new Wallet();
     mockWallet.setId(1L);
-    mockWallet.setAmountBalance(new Money().euros(800.00));
+    mockWallet.setAmountBalance(Money.euros(800.00));
+
+    mockCategory = new Category();
+    mockCategory.setId(1L);
+    mockCategory.setCategoryName("category name");
+    mockCategory.setType(CategoryType.DEBIT);
 
     mockTransaction = new Transaction();
     mockTransaction.setId(1L);
-    mockTransaction.setAmount(new Money().euros(200));
-    mockTransaction.setType(TransactionType.DEBIT);
+    mockTransaction.setAmount(Money.euros(200));
     mockTransaction.setWallet(mockWallet);
+    mockTransaction.setCategory(mockCategory);
   }
 
   @Test
@@ -83,15 +93,18 @@ class TransactionServiceUpdateUnitTest {
   @Test
   void shouldUpdateNoteField() {
     when(transactionRepository.findById(1L)).thenReturn(Optional.of(mockTransaction));
+    when(categoryRepository.findById(1L)).thenReturn(Optional.of(mockCategory));
     when(walletRepository.findById(any())).thenReturn(Optional.of(mockWallet));
     when(transactionRepository.save(any())).thenReturn(mockTransaction);
 
     TransactionUpdateDto updateDto = new TransactionUpdateDto();
+    updateDto.setCategoryId(mockCategory.getId());
     updateDto.setNote("Nouvelle note");
 
     transactionService.update(1L, updateDto);
 
     assertEquals("Nouvelle note", mockTransaction.getNote());
+    assertEquals(mockCategory.getId(), mockTransaction.getCategory().getId());
     verify(transactionRepository).save(mockTransaction);
   }
 
@@ -105,7 +118,7 @@ class TransactionServiceUpdateUnitTest {
   @Test
   void shouldHandleNullFieldsWithoutChangingOriginalValues() {
     final Money originalAmount = mockTransaction.getAmount();
-    final TransactionType originalType = mockTransaction.getType();
+    final CategoryType originalType = mockTransaction.getCategoryType();
 
     when(transactionRepository.findById(1L)).thenReturn(Optional.of(mockTransaction));
     when(walletRepository.findById(any())).thenReturn(Optional.of(mockWallet));
@@ -116,7 +129,7 @@ class TransactionServiceUpdateUnitTest {
     transactionService.update(1L, updateDto);
 
     assertEquals(originalAmount, mockTransaction.getAmount());
-    assertEquals(originalType, mockTransaction.getType());
+    assertEquals(originalType, mockTransaction.getCategoryType());
   }
 
   @Test


### PR DESCRIPTION
# Checklist

- [x] run `npm run test` or `mvn test`
- [x] les messages de commit et le nom de la pull request suivent les [Guidelines](https://github.com/Pecunia-App/.github/tree/main/profile#guidelines)

## [65](https://tree.taiga.io/project/lenny-zanotelli-pecunia/us/65?milestone=474304)

- Le champ "type" dans TRANSACTION est remplacé par le type de l'entité CATEGORY, pour éviter une redundance
- Modification des tests et de la logique métier en rapport avec le champ type de TRANSACTION
- Création de l'entité, le repository, le controller, les DTOs, les mapper,le service pour CATEGORY
- Mis à jour des tests d'intégration et de test unitaires pour TRANSACTION SERVICE
